### PR TITLE
Fix token display when contract lacks description

### DIFF
--- a/src/backend_task/contract.rs
+++ b/src/backend_task/contract.rs
@@ -124,21 +124,19 @@ impl AppContext {
                                     token_infos.push(token_info);
                                 }
 
-                                if let Some(document) = document_option {
-                                    let contract_description_info = ContractDescriptionInfo {
-                                        data_contract_id: contract.id(),
-                                        description: document
-                                            .get("description")
-                                            .and_then(|v| v.as_text())
-                                            .unwrap_or_default()
-                                            .to_string(),
-                                    };
+                                let contract_description_info = document_option.map(|document| ContractDescriptionInfo {
+                                    data_contract_id: contract.id(),
+                                    description: document
+                                        .get("description")
+                                        .and_then(|v| v.as_text())
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                });
 
-                                    results.insert(
-                                        contract.id(),
-                                        (Some(contract_description_info), token_infos),
-                                    );
-                                }
+                                results.insert(
+                                    contract.id(),
+                                    (contract_description_info, token_infos),
+                                );
                             }
                         }
                         Ok(BackendTaskSuccessResult::ContractsWithDescriptions(results))


### PR DESCRIPTION
## Summary
- ensure `FetchContractsWithDescriptions` returns token info even if contract description is missing

## Testing
- `cargo test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684ad71ce2608323927a24787f35ce35