### PR TITLE
Handle multi-wallet selection

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -92,6 +92,97 @@ impl AppContext {
         let network_config = config.config_for_network(network).clone()?;
         let (sx_zmq_status, rx_zmq_status) = crossbeam_channel::unbounded();
 
+        let mut addr = format!(
+            "http://{}:{}",
+            network_config.core_host, network_config.core_rpc_port
+        );
+        let cookie_path = core_cookie_path(network, &network_config.devnet_name)
+            .expect("expected to get cookie path");
+
+        // Determine which Dash Core wallet to use
+        let stored_wallet = db
+            .get_settings()
+            .ok()
+            .and_then(|opt| opt.map(Settings::from).and_then(|s| s.core_wallet_name));
+
+        let wallet_name = if let Some(name) = stored_wallet {
+            // Verify that wallet is loaded
+            match Client::new(&addr, Auth::CookieFile(cookie_path.clone())) {
+                Ok(tmp_client) => {
+                    if let Ok(list) = tmp_client.list_wallets() {
+                        if list.contains(&name) {
+                            Some(name)
+                        } else {
+                            println!(
+                                "Configured wallet '{}' not loaded in Dash Core.",
+                                name
+                            );
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
+                Err(_) => None,
+            }
+        } else {
+            match Client::new(&addr, Auth::CookieFile(cookie_path.clone())) {
+                Ok(tmp_client) => match tmp_client.list_wallets() {
+                    Ok(wallets) => {
+                        if wallets.is_empty() {
+                            println!(
+                                "No wallets loaded. Please load a wallet in Dash Core and restart."
+                            );
+                            return None;
+                        } else if wallets.len() == 1 {
+                            let w = wallets[0].clone();
+                            println!("Wallet detected: '{}'. Use this wallet? [y/N]", w);
+                            let mut input = String::new();
+                            if std::io::stdin().read_line(&mut input).is_err() {
+                                return None;
+                            }
+                            if input.trim().eq_ignore_ascii_case("y") {
+                                let _ = db.update_core_wallet_name(Some(&w));
+                                Some(w)
+                            } else {
+                                println!("Wallet not confirmed. Exiting.");
+                                return None;
+                            }
+                        } else {
+                            println!("Available wallets:");
+                            for (i, w) in wallets.iter().enumerate() {
+                                println!("{}. {}", i + 1, w);
+                            }
+                            println!("Enter wallet number:");
+                            let mut input = String::new();
+                            if std::io::stdin().read_line(&mut input).is_err() {
+                                return None;
+                            }
+                            if let Ok(idx) = input.trim().parse::<usize>() {
+                                if idx >= 1 && idx <= wallets.len() {
+                                    let selected = wallets[idx - 1].clone();
+                                    let _ = db.update_core_wallet_name(Some(&selected));
+                                    Some(selected)
+                                } else {
+                                    println!("Invalid selection.");
+                                    return None;
+                                }
+                            } else {
+                                println!("Invalid input.");
+                                return None;
+                            }
+                        }
+                    }
+                    Err(_) => None,
+                },
+                Err(_) => None,
+            }
+        };
+
+        if let Some(ref name) = wallet_name {
+            addr = format!("{}/wallet/{}", addr, name);
+        }
+
         // we create provider, but we need to set app context to it later, as we have a circular dependency
         let provider =
             Provider::new(db.clone(), network, &network_config).expect("Failed to initialize SDK");
@@ -113,13 +204,6 @@ impl AppContext {
         let keyword_search_contract =
             load_system_data_contract(SystemDataContract::KeywordSearch, platform_version)
                 .expect("expected to get keyword search contract");
-
-        let addr = format!(
-            "http://{}:{}",
-            network_config.core_host, network_config.core_rpc_port
-        );
-        let cookie_path = core_cookie_path(network, &network_config.devnet_name)
-            .expect("expected to get cookie path");
 
         // Try cookie authentication first
         let core_client = match Client::new(&addr, Auth::CookieFile(cookie_path.clone())) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,7 +18,7 @@ use bincode::config;
 use crossbeam_channel::{Receiver, Sender};
 use dash_sdk::Sdk;
 use dash_sdk::dashcore_rpc::dashcore::{InstantLock, Transaction};
-use dash_sdk::dashcore_rpc::{Auth, Client};
+use dash_sdk::dashcore_rpc::{Auth, Client, RpcApi};
 use dash_sdk::dpp::dashcore::hashes::Hash;
 use dash_sdk::dpp::dashcore::transaction::special_transaction::TransactionPayload::AssetLockPayloadType;
 use dash_sdk::dpp::dashcore::{Address, Network, OutPoint, TxOut, Txid};

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 11;
+pub const DEFAULT_DB_VERSION: u16 = 12;
 
 pub const DEFAULT_NETWORK: &str = "dash";
 
@@ -34,6 +34,9 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
+            12 => {
+                self.add_core_wallet_name_column(tx)?;
+            }
             11 => self.rename_identity_column_is_in_creation_to_status(tx)?,
             10 => {
                 self.add_theme_preference_column(tx)?;
@@ -216,6 +219,7 @@ impl Database {
             custom_dash_qt_path TEXT,
             overwrite_dash_conf INTEGER,
             theme_preference TEXT DEFAULT 'System',
+            core_wallet_name TEXT,
             database_version INTEGER NOT NULL
         )",
             [],

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -15,6 +15,7 @@ pub struct Settings {
     pub dash_qt_path: Option<PathBuf>,
     pub overwrite_dash_conf: bool,
     pub theme_mode: ThemeMode,
+    pub core_wallet_name: Option<String>,
 }
 
 impl
@@ -25,6 +26,7 @@ impl
         Option<PathBuf>,
         bool,
         ThemeMode,
+        Option<String>,
     )> for Settings
 {
     /// Converts a tuple into a Settings instance
@@ -38,9 +40,18 @@ impl
             Option<PathBuf>,
             bool,
             ThemeMode,
+            Option<String>,
         ),
     ) -> Self {
-        Self::new(tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5)
+        Self::new(
+            tuple.0,
+            tuple.1,
+            tuple.2,
+            tuple.3,
+            tuple.4,
+            tuple.5,
+            tuple.6,
+        )
     }
 }
 
@@ -54,6 +65,7 @@ impl Default for Settings {
             None, // autodetect
             true,
             ThemeMode::System,
+            None,
         )
     }
 }
@@ -67,6 +79,7 @@ impl Settings {
         dash_qt_path: Option<PathBuf>,
         overwrite_dash_conf: bool,
         theme_mode: ThemeMode,
+        core_wallet_name: Option<String>,
     ) -> Self {
         Self {
             network,
@@ -75,6 +88,7 @@ impl Settings {
             dash_qt_path: dash_qt_path.or_else(detect_dash_qt_path),
             overwrite_dash_conf,
             theme_mode,
+            core_wallet_name,
         }
     }
 }


### PR DESCRIPTION
## Summary
- store selected wallet name in settings
- add migration for new `core_wallet_name` column
- prompt user to choose a wallet if one isn't configured
- use selected wallet when connecting to Dash Core RPC

## Testing
- `cargo check` *(fails: failed to run custom build command for `tenderdash-proto`)*

------
https://chatgpt.com/codex/tasks/task_e_687ff81b536c832395b892441d922a53