### PR TITLE
Add wallet selection and wallet-aware RPC

### DIFF
--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -142,10 +142,10 @@ impl AppContext {
                     asset_lock_proof.as_ref()
                 {
                     // we need to make sure the instant send asset lock is recent
-                    let raw_transaction_info = self
-                        .core_client
+                    let raw_transaction_info = wallet
                         .read()
-                        .expect("Core client lock was poisoned")
+                        .map_err(|e| e.to_string())?
+                        .rpc_client(self)?
                         .get_raw_transaction_info(&tx_id, None)
                         .map_err(|e| e.to_string())?;
 
@@ -181,12 +181,9 @@ impl AppContext {
                     ) {
                         Ok(transaction) => transaction,
                         Err(_) => {
-                            wallet
-                                .reload_utxos(
-                                    &self
-                                        .core_client
-                                        .read()
-                                        .expect("Core client lock was poisoned"),
+                            let client = wallet.rpc_client(self)?;
+                            wallet.reload_utxos(
+                                    &client,
                                     self.network,
                                     Some(self),
                                 )
@@ -215,9 +212,10 @@ impl AppContext {
                     proofs.insert(tx_id, None);
                 }
 
-                self.core_client
+                wallet
                     .read()
-                    .expect("Core client lock was poisoned")
+                    .map_err(|e| e.to_string())?
+                    .rpc_client(self)?
                     .send_raw_transaction(&asset_lock_transaction)
                     .map_err(|e| e.to_string())?;
 
@@ -282,9 +280,10 @@ impl AppContext {
                     proofs.insert(tx_id, None);
                 }
 
-                self.core_client
+                wallet
                     .read()
-                    .expect("Core client lock was poisoned")
+                    .map_err(|e| e.to_string())?
+                    .rpc_client(self)?
                     .send_raw_transaction(&asset_lock_transaction)
                     .map_err(|e| e.to_string())?;
 

--- a/src/backend_task/identity/top_up_identity.rs
+++ b/src/backend_task/identity/top_up_identity.rs
@@ -57,10 +57,10 @@ impl AppContext {
                             asset_lock_proof.as_ref()
                         {
                             // we need to make sure the instant send asset lock is recent
-                            let raw_transaction_info = self
-                                .core_client
+                            let raw_transaction_info = wallet
                                 .read()
-                                .expect("Core client lock was poisoned")
+                                .map_err(|e| e.to_string())?
+                                .rpc_client(self)?
                                 .get_raw_transaction_info(&tx_id, None)
                                 .map_err(|e| e.to_string())?;
 
@@ -100,12 +100,9 @@ impl AppContext {
                         ) {
                             Ok(transaction) => transaction,
                             Err(_) => {
-                                wallet
-                                    .reload_utxos(
-                                        &self
-                                            .core_client
-                                            .read()
-                                            .expect("Core client lock was poisoned"),
+                                let client = wallet.rpc_client(self)?;
+                                wallet.reload_utxos(
+                                        &client,
                                         self.network,
                                         Some(self),
                                     )
@@ -135,9 +132,10 @@ impl AppContext {
                         proofs.insert(tx_id, None);
                     }
 
-                    self.core_client
+                    wallet
                         .read()
-                        .expect("Core client lock was poisoned")
+                        .map_err(|e| e.to_string())?
+                        .rpc_client(self)?
                         .send_raw_transaction(&asset_lock_transaction)
                         .map_err(|e| e.to_string())?;
 
@@ -208,9 +206,10 @@ impl AppContext {
                         proofs.insert(tx_id, None);
                     }
 
-                    self.core_client
+                    wallet
                         .read()
-                        .expect("Core client lock was poisoned")
+                        .map_err(|e| e.to_string())?
+                        .rpc_client(self)?
                         .send_raw_transaction(&asset_lock_transaction)
                         .map_err(|e| e.to_string())?;
 

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 11;
+pub const DEFAULT_DB_VERSION: u16 = 12;
 
 pub const DEFAULT_NETWORK: &str = "dash";
 
@@ -34,6 +34,7 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
+            12 => self.add_core_wallet_name_column(tx)?,
             11 => self.rename_identity_column_is_in_creation_to_status(tx)?,
             10 => {
                 self.add_theme_preference_column(tx)?;
@@ -230,6 +231,7 @@ impl Database {
                 nonce BLOB NOT NULL,
                 master_ecdsa_bip44_account_0_epk BLOB NOT NULL,
                 alias TEXT,
+                core_wallet_name TEXT,
                 is_main INTEGER,
                 uses_password INTEGER NOT NULL,
                 password_hint TEXT,

--- a/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
@@ -29,10 +29,8 @@ impl AddNewIdentityScreen {
 
                     if let Some(has_address) = self.core_has_funding_address {
                         if !has_address {
-                            self.app_context
-                                .core_client
-                                .read()
-                                .expect("Core client lock was poisoned")
+                            wallet
+                                .rpc_client(&self.app_context)?
                                 .import_address(
                                     &receive_address,
                                     Some("Managed by Dash Evo Tool"),
@@ -42,19 +40,14 @@ impl AddNewIdentityScreen {
                         }
                         self.funding_address = Some(receive_address);
                     } else {
-                        let info = self
-                            .app_context
-                            .core_client
-                            .read()
-                            .expect("Core client lock was poisoned")
+                        let info = wallet
+                            .rpc_client(&self.app_context)?
                             .get_address_info(&receive_address)
                             .map_err(|e| e.to_string())?;
 
                         if !(info.is_watchonly || info.is_mine) {
-                            self.app_context
-                                .core_client
-                                .read()
-                                .expect("Core client lock was poisoned")
+                            wallet
+                                .rpc_client(&self.app_context)?
                                 .import_address(
                                     &receive_address,
                                     Some("Managed by Dash Evo Tool"),

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -22,18 +22,14 @@ impl TopUpIdentityScreen {
                     )?;
 
                     // Import address to Core if needed for monitoring
-                    let core_client = self
-                        .app_context
-                        .core_client
-                        .read()
-                        .map_err(|_| "Core client lock was poisoned".to_string())?;
-
-                    let info = core_client
+                    let client = wallet
+                        .rpc_client(&self.app_context)?;
+                    let info = client
                         .get_address_info(&receive_address)
                         .map_err(|e| e.to_string())?;
 
                     if !(info.is_watchonly || info.is_mine) {
-                        core_client
+                        client
                             .import_address(
                                 &receive_address,
                                 Some("Managed by Dash Evo Tool"),
@@ -42,7 +38,6 @@ impl TopUpIdentityScreen {
                             .map_err(|e| e.to_string())?;
                     }
 
-                    drop(core_client);
 
                     self.funding_address = Some(receive_address.clone());
                     receive_address

--- a/src/ui/wallets/import_wallet_screen.rs
+++ b/src/ui/wallets/import_wallet_screen.rs
@@ -107,6 +107,7 @@ impl ImportWalletScreen {
                 watched_addresses: Default::default(),
                 unused_asset_locks: Default::default(),
                 alias: Some(self.alias_input.clone()),
+                core_wallet_name: None,
                 identities: Default::default(),
                 utxos: Default::default(),
                 is_main: true,


### PR DESCRIPTION
## Summary
- store core wallet name with each DET wallet
- migrate DB to keep wallet names
- fetch open Core wallets when creating a wallet
- use wallet-specific RPC clients across wallet operations

## Testing
- `cargo clippy --all-features --all-targets -- -D warnings` *(fails: Tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688111ae9bac832381ba648c4e9ff776